### PR TITLE
Implement simple config for dockopt

### DIFF
--- a/pydock3/dockopt/config.py
+++ b/pydock3/dockopt/config.py
@@ -12,6 +12,10 @@ DOCKOPT_CONFIG_SCHEMA_FILE_PATH = os.path.join(
     os.path.dirname(DOCKOPT_INIT_FILE_PATH), "dockopt_config_schema.yaml"
 )
 
+# Simple config addition
+DOCKOPT_SIMPLE_CONFIG_SCHEMA_FILE_PATH = os.path.join(
+    os.path.dirname(DOCKOPT_INIT_FILE_PATH), "dockopt_simple_config_schema.yaml"
+)
 
 #
 logger = logging.getLogger(__name__)
@@ -19,8 +23,44 @@ logger.setLevel(logging.DEBUG)
 
 
 class DockoptParametersConfiguration(ParametersConfiguration):
-    def __init__(self, config_file_path):
+    def __init__(self, config_file_path, simple=False):
+        schema_file_path = DOCKOPT_SIMPLE_CONFIG_SCHEMA_FILE_PATH if simple else DOCKOPT_CONFIG_SCHEMA_FILE_PATH
         super().__init__(
             config_file_path=config_file_path,
-            schema_file_path=DOCKOPT_CONFIG_SCHEMA_FILE_PATH,
+            schema_file_path=schema_file_path,
         )
+    
+
+    def override_w_simple_config(self, simple_config):
+        """
+        Zack Mawaldi
+        Overrides the current configuration with values from the simple config... Manually.
+        I know it's cursed, but given that steps is a list, I found this to be the easiest to understand solution.
+        
+        Args:
+            simple_config (DockoptParametersConfiguration): The simple configuration object to override with.
+        """
+        # Extract the parameter dictionaries
+        advanced = self.param_dict
+        simple = simple_config.param_dict
+
+        # Perform the overrides
+        advanced['definitions']['steps'][0]['step']['top_n'] = simple['definitions']['steps'][0]['step']['top_n']
+        advanced['definitions']['steps'][1]['step']['top_n'] = simple['definitions']['steps'][0]['step']['top_n']
+        
+        advanced['definitions']['steps'][0]['step']['parameters']['dock_files_generation']['thin_spheres_elec']['use'] = \
+          simple['definitions']['steps'][0]['step']['parameters']['dock_files_generation']['thin_spheres_elec']['use']
+        
+        advanced['definitions']['steps'][0]['step']['parameters']['dock_files_generation']['thin_spheres_elec']['distance_to_surface'] = \
+          simple['definitions']['steps'][0]['step']['parameters']['dock_files_generation']['thin_spheres_elec']['distance_to_surface']
+
+        advanced['definitions']['steps'][0]['step']['parameters']['dock_files_generation']['thin_spheres_desolv']['distance_to_surface'] = \
+          simple['definitions']['steps'][0]['step']['parameters']['dock_files_generation']['thin_spheres_desolv']['distance_to_surface']
+        
+        advanced['definitions']['steps'][0]['step']['parameters']['dock_files_generation']['thin_spheres_desolv']['use'] = \
+          simple['definitions']['steps'][0]['step']['parameters']['dock_files_generation']['thin_spheres_desolv']['use']
+
+        advanced['definitions']['steps'][0]['step']['parameters']['dock_files_modification']['matching_spheres_perturbation'] = \
+          simple['definitions']['steps'][0]['step']['parameters']['dock_files_modification']['matching_spheres_perturbation']
+
+        advanced['pipeline']['top_n'] = simple['pipeline']['top_n']

--- a/pydock3/dockopt/default_dockopt_config.yaml
+++ b/pydock3/dockopt/default_dockopt_config.yaml
@@ -1,7 +1,7 @@
 definitions:
   steps:
   - step: &id004
-      top_n: 1000 # 10 thin_spheres_elec elec * 10 thin_spheres_desolv desolv * 10 matching_spheres_perturbation
+      top_n: 25
       criterion: normalized_log_auc
       dock_files_to_use_from_previous_component:
         matching_spheres_file: false
@@ -20,7 +20,7 @@ definitions:
           thin_spheres_elec:
             use: true
             molecular_surface_density: 1.0
-            distance_to_surface: [1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0]
+            distance_to_surface: [1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0, 2.1, 2.2]
             penetration: 0.0
             distance_to_ligand: 2.0
           thin_spheres_desolv:
@@ -201,9 +201,7 @@ definitions:
       components:
       - step: *id003
 pipeline:
-  top_n: 1000 # 10 thin_spheres_elec elec * 10 thin_spheres_desolv desolv * 10 matching_spheres_perturbation
+  top_n: 25
   criterion: normalized_log_auc
   components:
   - step: *id004
-  # - step: *id005
-  # - sequence: *id006

--- a/pydock3/dockopt/default_dockopt_config.yaml
+++ b/pydock3/dockopt/default_dockopt_config.yaml
@@ -1,7 +1,7 @@
 definitions:
   steps:
   - step: &id004
-      top_n: 25
+      top_n: 1000 # 10 thin_spheres_elec elec * 10 thin_spheres_desolv desolv * 10 matching_spheres_perturbation
       criterion: normalized_log_auc
       dock_files_to_use_from_previous_component:
         matching_spheres_file: false
@@ -20,7 +20,7 @@ definitions:
           thin_spheres_elec:
             use: true
             molecular_surface_density: 1.0
-            distance_to_surface: [1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0, 2.1, 2.2]
+            distance_to_surface: [1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0]
             penetration: 0.0
             distance_to_ligand: 2.0
           thin_spheres_desolv:
@@ -201,9 +201,9 @@ definitions:
       components:
       - step: *id003
 pipeline:
-  top_n: 5
+  top_n: 1000 # 10 thin_spheres_elec elec * 10 thin_spheres_desolv desolv * 10 matching_spheres_perturbation
   criterion: normalized_log_auc
   components:
   - step: *id004
-  - step: *id005
-  - sequence: *id006
+  # - step: *id005
+  # - sequence: *id006

--- a/pydock3/dockopt/default_simple_dockopt_config.yaml
+++ b/pydock3/dockopt/default_simple_dockopt_config.yaml
@@ -1,0 +1,26 @@
+definitions:
+  steps:
+  - step: &id004
+      top_n: 1000 # 10 thin_spheres_elec elec * 10 thin_spheres_desolv desolv * 10 matching_spheres_perturbation
+      parameters:
+        dock_files_generation: &id002
+
+          thin_spheres_elec:
+            use: true
+            molecular_surface_density: 1.0
+            distance_to_surface: [1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0]
+            penetration: 0.0
+            distance_to_ligand: 2.0
+
+          thin_spheres_desolv:
+            use: true
+            molecular_surface_density: 1.0
+            distance_to_surface: [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
+            penetration: 0.0
+            distance_to_ligand: 2.0
+
+        dock_files_modification:
+          matching_spheres_perturbation:
+            use: true
+            num_samples_per_matching_spheres_file: 10
+            max_deviation_angstroms: 0.4

--- a/pydock3/dockopt/default_simple_dockopt_config.yaml
+++ b/pydock3/dockopt/default_simple_dockopt_config.yaml
@@ -1,26 +1,23 @@
 definitions:
   steps:
   - step: &id004
-      top_n: 1000 # 10 thin_spheres_elec elec * 10 thin_spheres_desolv desolv * 10 matching_spheres_perturbation
+      top_n: 1000
       parameters:
         dock_files_generation: &id002
 
           thin_spheres_elec:
             use: true
-            molecular_surface_density: 1.0
             distance_to_surface: [1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0]
-            penetration: 0.0
-            distance_to_ligand: 2.0
 
           thin_spheres_desolv:
             use: true
-            molecular_surface_density: 1.0
             distance_to_surface: [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
-            penetration: 0.0
-            distance_to_ligand: 2.0
 
         dock_files_modification:
           matching_spheres_perturbation:
             use: true
             num_samples_per_matching_spheres_file: 10
             max_deviation_angstroms: 0.4
+
+pipeline:
+  top_n: 1000 

--- a/pydock3/dockopt/dockopt.py
+++ b/pydock3/dockopt/dockopt.py
@@ -98,10 +98,14 @@ class DockoptPipelineComponentRunFuncArgSet:  # TODO: rename?
 class Dockopt(Script):
     JOB_DIR_NAME = "dockopt_job"
     CONFIG_FILE_NAME = "dockopt_config.yaml"
+    SIMPLE_CONFIG_FILE_NAME = "simple_dockopt_config.yaml"
     ACTIVES_TGZ_FILE_NAME = "actives.tgz"
     DECOYS_TGZ_FILE_NAME = "decoys.tgz"
     DEFAULT_CONFIG_FILE_PATH = os.path.join(
         os.path.dirname(DOCKOPT_INIT_FILE_PATH), "default_dockopt_config.yaml"
+    )
+    DEFAULT_SIMPLE_CONFIG_FILE_PATH = os.path.join(
+        os.path.dirname(DOCKOPT_INIT_FILE_PATH), "default_simple_dockopt_config.yaml"
     )
 
     def __init__(self) -> None:
@@ -171,6 +175,12 @@ class Dockopt(Script):
         save_path = os.path.join(job_dir.path, self.CONFIG_FILE_NAME)
         DockoptParametersConfiguration.write_config_file(
             save_path, self.DEFAULT_CONFIG_FILE_PATH
+        )
+
+        # write the simple version as well. first, we switch out schema to simple
+        save_path = os.path.join(job_dir.path, self.SIMPLE_CONFIG_FILE_NAME)    
+        DockoptParametersConfiguration.write_config_file(
+            save_path, self.DEFAULT_SIMPLE_CONFIG_FILE_PATH
         )
 
     @handle_run_func.__get__(0)

--- a/pydock3/dockopt/dockopt.py
+++ b/pydock3/dockopt/dockopt.py
@@ -189,6 +189,7 @@ class Dockopt(Script):
         scheduler: str,
         job_dir_path: str = ".",
         config_file_path: Optional[str] = None,
+        simple_config_file_path: Optional[str] = None,
         actives_tgz_file_path: Optional[str] = None,
         decoys_tgz_file_path: Optional[str] = None,
         retrodock_job_max_reattempts: int = 0,
@@ -203,6 +204,7 @@ class Dockopt(Script):
         force_redock: bool = False,
         force_rewrite_results: bool = False,
         force_rewrite_report: bool = False,
+        advanced_mode: bool = False,
     ) -> None:
         """Run DockOpt job."""
 
@@ -213,6 +215,8 @@ class Dockopt(Script):
         # validate args
         if config_file_path is None:
             config_file_path = os.path.join(job_dir_path, self.CONFIG_FILE_NAME)
+        if simple_config_file_path is None:
+            simple_config_file_path = os.path.join(job_dir_path, self.SIMPLE_CONFIG_FILE_NAME)
         if actives_tgz_file_path is None:
             actives_tgz_file_path = os.path.join(job_dir_path, self.ACTIVES_TGZ_FILE_NAME)
         if decoys_tgz_file_path is None:
@@ -275,6 +279,15 @@ class Dockopt(Script):
         #
         logger.info("Loading config file")
         config = DockoptParametersConfiguration(config_file_path)
+        
+        if not advanced_mode:
+            simple_config = DockoptParametersConfiguration(simple_config_file_path, simple=True)
+            config.override_w_simple_config(simple_config)
+
+            logger.info(f"Running Dockopt using {os.path.basename(simple_config_file_path)} with advanced settings found in {os.path.basename(config_file_path)} (Simple mode)")
+        else:
+            logger.info(f"Running Dockopt using only the settings from {os.path.basename(config_file_path)} (Advacned mode)")
+
 
         #
         config_params_str = "\n".join(

--- a/pydock3/dockopt/dockopt_simple_config_schema.yaml
+++ b/pydock3/dockopt/dockopt_simple_config_schema.yaml
@@ -1,0 +1,26 @@
+definitions:
+  steps:
+    list(include('step_list_item'), min=1)
+pipeline:
+  top_n: num()
+
+---
+
+step:
+  top_n: num()
+  parameters:
+    dock_files_generation:
+      thin_spheres_elec:
+        use: bool()
+        distance_to_surface: list(num())
+      thin_spheres_desolv:
+        use: bool()
+        distance_to_surface: list(num())
+    dock_files_modification:
+      matching_spheres_perturbation:
+        use: bool()
+        num_samples_per_matching_spheres_file: num()
+        max_deviation_angstroms: num()
+
+step_list_item:
+  step: include('step')


### PR DESCRIPTION
The goal here is to make dockopt less intimidating to use via a simplified config file option. This came about from a discussion with Brendan Hall during hackathon we had last week.

The main differences form current branch is that:
When you run `pydock3 dockopt - new`, you get a new file: `simple_dockopt_config.yaml`. This file will be used as an effective default config file. User can ask for `--advanced_mode=True` in `pydock3 dockopt - run`, which would run dockopt as it is run currently.

The new simple mode does:
1. When dockopt is run in simple mode: `pydock3 dockopt - run`, dockopt loads both simple and default config files, and replaces any shared values with simple values.
2. If `pydock3 dockopt - run --advanced_mode=True`, then original behavior is maintained (load the original config file)

Some modifications to default dropped config file was made, which made default config be only 1 step. This is because since for 99% of dockopt jobs, there is no need for more than one step to avoid overfitting.

Documentation is written on the new documentation place of [read-the-dock-docs](https://github.com/bwhall61/read-the-dock-docs) made by Brendan. There should be a pull request there soon.


Note on testing:
I did some testing and it seems to work as intended. I highly recommend someone else tests my branch to make sure it's working! I have it installed and working on gimel @ `~/zack/pydock_testing/pydock3/`

Thanks! Lmk if anyone has any questions.