### PR TITLE
Fix bug when molecular_surface_density not set

### DIFF
--- a/pydock3/blastermaster/blastermaster.py
+++ b/pydock3/blastermaster/blastermaster.py
@@ -134,7 +134,11 @@ def get_blaster_steps(blaster_files, flat_param_dict, working_dir):
             binding_site_residues_infile=blaster_files.binding_site_residues_file,
             radii_infile=blaster_files.molecular_surface_radii_file,
             molecular_surface_outfile=blaster_files.molecular_surface_file,
-            molecular_surface_density_parameter=flat_param_dict['molecular_surface_density'],
+            **(
+                {'molecular_surface_density_parameter': flat_param_dict['molecular_surface_density']}
+                if 'molecular_surface_density' in flat_param_dict
+                else {}
+            )
         )
     )
 


### PR DESCRIPTION
This fixed a bug where you had to provide a "molecular_surface_density" parameter in the config. Intended behavior was to use a default of 5.0 if not supplied, but it would throw an error if it wasn't.